### PR TITLE
Fix off-by-one-ish bug

### DIFF
--- a/FBONightly/etl.py
+++ b/FBONightly/etl.py
@@ -183,8 +183,8 @@ def fname_urls(self):
     if datetime.now().hour < 17:
         x += 1
 
-    # Each time we run this, we add download extra files to get at the backload
-    maximum = len(os.listdir(self.datadir)) + 2
+    # Each time we run this, we download extra files to get at the backload
+    maximum = len(os.listdir(self.datadir)) + 3
 
     while x < maximum:
         today = date.today() - timedelta(x)


### PR DESCRIPTION
Increase maximum to account for the weekend.

The bug is that if a person ran the download script for the first time
on a Monday before 5pm, as I did, they wouldn't get any files.  The
datadir would have no existing files (0) and adding 2 means that the
maximum was equal to x (yesterday plus another day is two days ago), so
no download was performed, because of the `while`.  Even if it had, I don't know if there are FBO files on Saturdays.  Adding three instead of two to the maximum addresses this,
and a person running the download on a Monday with an empty datadir will
now get Friday's file.